### PR TITLE
Issue #11: Set Up CMake for `drift-camera`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_STORE
 .DS_STORE
 __MACOSX
+
+build
+.cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/tracking"]
+	path = src/tracking
+	url = git@github.com:jlevis10/drift-tracking.git

--- a/README.md
+++ b/README.md
@@ -1,16 +1,2 @@
 # DRIFT_FW
 Firmware repo for DRIFT Capstone Project
-
-## Firmware Overview
-[TO DO]
-
-## Directory Structure:
-```
-.
-|───src     # Contains all firmware code
-|   |
-|   |───prod     # Contains latest version of tested code
-|   └───dev     # Contains latest version of untested code
-|
-└───README.md   # this file!
-```

--- a/src/drift-camera/CMakeLists.txt
+++ b/src/drift-camera/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Set the minimum required version of CMake
+cmake_minimum_required(VERSION 3.10)
+
+# Create the project
+project(drift-camera
+    VERSION 1.0
+    DESCRIPTION "DRIFT Raspberry Pi Global Shutter Camera Image Processing Application"
+    LANGUAGES CXX
+)
+
+# Set C++ standards
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Provides compile_commands.json for LSP autocompletion
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+add_compile_options(
+    -lcamera
+)
+
+# Use PkgConfig to link libcamera
+find_package(PkgConfig REQUIRED)
+
+# Import libcamera libraries
+pkg_check_modules(LIBCAMERA REQUIRED IMPORTED_TARGET libcamera)
+message(STATUS "libcamera library found:")
+message(STATUS "    Version: ${LIBCAMERA_VERSION}")
+message(STATUS "    Libraries: ${LIBCAMERA_LINK_LIBRARIES}")
+message(STATUS "    Include Path: ${LIBCAMERA_INCLUDE_DIRS}")
+
+# Add source files
+add_executable(drift-camera
+    ./src/camera.cpp
+    ./src/drift_camera_main.cpp
+)
+
+# Necesssary includes
+target_include_directories(drift-camera PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    ${CMAKE_SOURCE_DIR}
+    ${LIBCAMERA_INCLUDE_DIRS}
+)
+
+target_link_libraries(drift-camera PkgConfig::LIBCAMERA)

--- a/src/drift-camera/custom-build.sh
+++ b/src/drift-camera/custom-build.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+EXIT_SUCCESS=0
+EXIT_FAILURE=1
+
+RED="\033[31m"
+GREEN="\033[32m"
+RESET="\033[0m"
+
+ROOT_DIR="drift-camera"
+BUILD_DIR="build"
+
+check_run_directory() {
+    local build_run_dir="$1"
+    local current_dir="$(basename $PWD)"
+
+    if [[ "$current_dir" != "$build_run_dir" ]]; then
+        echo "Attempting to build drift-camera from an incorrect directory"
+        echo "Navigate to drift-camera and then try again"
+        return "$EXIT_FAILURE"
+    fi
+}
+
+if ! check_run_directory "$ROOT_DIR"; then
+    echo -e "${RED}BUILD FAILED"
+    exit "$EXIT_FAILURE"
+fi
+
+if [ ! -d "$BUILD_DIR" ]; then
+    mkdir "$BUILD_DIR"
+fi
+cd "$BUILD_DIR"
+
+if ! cmake ..; then
+    echo -e "${RED}BUILD FAILED"
+    exit "$EXIT_FAILURE"
+fi
+
+if ! cmake --build .; then
+    echo -e "${RED}BUILD FAILED"
+    exit "$EXIT_FAILURE"
+fi
+
+echo -e "${GREEN}BUILD SUCCEEDED${RESET}"
+
+exit "$EXIT_SUCCESS"

--- a/src/drift-camera/include/camera.hpp
+++ b/src/drift-camera/include/camera.hpp
@@ -1,0 +1,16 @@
+#include <cstdint>
+#include <libcamera/libcamera.h>
+#include <memory>
+
+class Camera {
+  public:
+    Camera();
+    ~Camera() = default;
+
+    int8_t start_camera();
+
+    void print_cameras();
+
+  private:
+    std::unique_ptr<libcamera::CameraManager> camera_manager;
+};

--- a/src/drift-camera/src/camera.cpp
+++ b/src/drift-camera/src/camera.cpp
@@ -1,0 +1,20 @@
+
+
+
+#include "camera.hpp"
+
+Camera::Camera() : camera_manager(std::make_unique<libcamera::CameraManager>()) {}
+
+int8_t Camera::start_camera()
+{
+    camera_manager->start();
+
+    return 0;
+}
+
+void Camera::print_cameras()
+{
+    for (auto const &camera : camera_manager->cameras()) {
+        fprintf(stdout, "%s\n", camera->id());
+    }
+}

--- a/src/drift-camera/src/drift_camera_main.cpp
+++ b/src/drift-camera/src/drift_camera_main.cpp
@@ -1,0 +1,12 @@
+
+
+#include "camera.hpp"
+
+int main()
+{
+    Camera camera;
+
+    camera.print_cameras();
+
+    return 0;
+}


### PR DESCRIPTION
## Problem
In order to run our applications, we need a way to build and compile
them. Since our camera application, `drift-camera`, is currently being
developed, we should set up a build system for `drift-camera`.

## Solution
Created a `CMakeLists.txt` file to compile the `drift-camera`
application, which also links the `libcamera` library.

## Testing
Built and compiled on Ubuntu 24 and Raspberry Pi OS.