### PR TITLE
Issue 9: Receive Camera Frames

### DIFF
--- a/scripts/camera_test.cpp
+++ b/scripts/camera_test.cpp
@@ -1,0 +1,203 @@
+
+
+#include <cwchar>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <libcamera/libcamera/formats.h>
+#include <memory>
+#include <sys/mman.h>
+#include <thread>
+
+#include <libcamera/libcamera.h>
+
+#include <jpeglib.h>
+#include <vector>
+
+void save_jpeg_image(const uint8_t *data, int width, int height, const std::string &filename)
+{
+    struct jpeg_compress_struct cinfo;
+    struct jpeg_error_mgr jerr;
+    cinfo.err = jpeg_std_error(&jerr);
+    jpeg_create_compress(&cinfo);
+
+    std::FILE *outfile = fopen(filename.c_str(), "wb");
+    if (!outfile) {
+        fprintf(stderr, "Failed to open file for writing: %s\n", filename.c_str());
+        return;
+    }
+
+    jpeg_stdio_dest(&cinfo, outfile);
+    cinfo.image_width = width;
+    cinfo.image_height = height;
+    cinfo.input_components = 3;
+    cinfo.in_color_space = JCS_RGB;
+    jpeg_set_defaults(&cinfo);
+    jpeg_set_quality(&cinfo, 90, TRUE);
+    jpeg_start_compress(&cinfo, TRUE);
+
+    std::vector<uint8_t> rgb_data(width * height * 3);
+    for (int i = 0; i < width * height; ++i) {
+        rgb_data[i * 3 + 0] = data[i * 4 + 2];  // R
+        rgb_data[i * 3 + 1] = data[i * 4 + 1];  // G
+        rgb_data[i * 3 + 2] = data[i * 4 + 0];  // B
+    }
+
+    while (cinfo.next_scanline < cinfo.image_height) {
+        JSAMPROW row_pointer = (JSAMPROW)&rgb_data[cinfo.next_scanline * width * 3];
+        jpeg_write_scanlines(&cinfo, &row_pointer, 1);
+    }
+
+    jpeg_finish_compress(&cinfo);
+    jpeg_destroy_compress(&cinfo);
+    fclose(outfile);
+}
+
+static void *map_frame_buffer(const libcamera::FrameBuffer::Plane &plane)
+{
+    void *mapped_memory = mmap(nullptr, plane.length, PROT_READ | PROT_WRITE, MAP_SHARED, plane.fd.get(), plane.offset);
+    if (mapped_memory == MAP_FAILED) {
+        fprintf(stderr, "Failed to map memory\n");
+        return nullptr;
+    }
+    return mapped_memory;
+}
+
+using namespace libcamera;
+using namespace std::chrono_literals;
+
+static std::shared_ptr<Camera> camera;
+
+static void requestComplete(Request *request)
+{
+    if (request->status() == Request::RequestCancelled)
+        return;
+
+    const std::map<const Stream *, FrameBuffer *> &buffers = request->buffers();
+
+    for (auto bufferPair : buffers) {
+        FrameBuffer *buffer = bufferPair.second;
+        const FrameMetadata &metadata = buffer->metadata();
+        std::cout << " seq: " << std::setw(6) << std::setfill('0') << metadata.sequence << " bytesused: ";
+
+        unsigned int nplane = 0;
+        for (const FrameMetadata::Plane &plane : metadata.planes())
+        {
+            std::cout << plane.bytesused;
+            if (++nplane < metadata.planes().size()) std::cout << "/";
+        }
+
+        std::cout << std::endl;
+
+        libcamera::FrameBuffer::Plane plane = buffer->planes().at(0);
+
+        void *data = map_frame_buffer(plane);
+
+        const uint8_t *pixel_data = static_cast<const uint8_t *>(data);
+        int width = 800;
+        int height = 600;
+
+        std::string filename = "image1.jpg";
+        save_jpeg_image(pixel_data, width, height, filename);
+        fprintf(stdout, "Saved frame: %s\n", filename.c_str());
+    }
+
+    request->reuse(Request::ReuseBuffers);
+    camera->queueRequest(request);
+}
+
+int main()
+{
+    std::unique_ptr<CameraManager> cm = std::make_unique<CameraManager>();
+    cm->start();
+
+    for (auto const &camera : cm->cameras())
+        std::cout << camera->id() << std::endl;
+
+    auto cameras = cm->cameras();
+    if (cameras.empty()) {
+        std::cout << "No cameras were identified on the system."
+                  << std::endl;
+        cm->stop();
+        return EXIT_FAILURE;
+    }
+
+    std::string cameraId = cameras[0]->id();
+
+    camera = cm->get(cameraId);
+    /*
+     * Note that `camera` may not compare equal to `cameras[0]`.
+     * In fact, it might simply be a `nullptr`, as the particular
+     * device might have disappeared (and reappeared) in the meantime.
+     */
+
+    camera->acquire();
+
+    std::unique_ptr<CameraConfiguration> config = camera->generateConfiguration( { StreamRole::Viewfinder } );
+
+    StreamConfiguration &streamConfig = config->at(0);
+    std::cout << "Default viewfinder configuration is: " << streamConfig.toString() << std::endl;
+
+    streamConfig.pixelFormat = libcamera::formats::XRGB8888;
+    streamConfig.size.width = 800;
+    streamConfig.size.height = 600;
+
+    config->validate();
+    std::cout << "Validated viewfinder configuration is: " << streamConfig.toString() << std::endl;
+
+    camera->configure(config.get());
+
+    FrameBufferAllocator *allocator = new FrameBufferAllocator(camera);
+
+    for (StreamConfiguration &cfg : *config) {
+        int ret = allocator->allocate(cfg.stream());
+        if (ret < 0) {
+            std::cerr << "Can't allocate buffers" << std::endl;
+            return -ENOMEM;
+        }
+
+        size_t allocated = allocator->buffers(cfg.stream()).size();
+        std::cout << "Allocated " << allocated << " buffers for stream" << std::endl;
+    }
+
+    Stream *stream = streamConfig.stream();
+    const std::vector<std::unique_ptr<FrameBuffer>> &buffers = allocator->buffers(stream);
+    std::vector<std::unique_ptr<Request>> requests;
+
+    for (unsigned int i = 0; i < buffers.size(); ++i) {
+        std::unique_ptr<Request> request = camera->createRequest();
+        if (!request)
+        {
+            std::cerr << "Can't create request" << std::endl;
+            return -ENOMEM;
+        }
+
+        const std::unique_ptr<FrameBuffer> &buffer = buffers[i];
+        int ret = request->addBuffer(stream, buffer.get());
+        if (ret < 0)
+        {
+            std::cerr << "Can't set buffer for request"
+                  << std::endl;
+            return ret;
+        }
+
+        requests.push_back(std::move(request));
+    }
+
+    camera->requestCompleted.connect(requestComplete);
+
+    camera->start();
+    for (std::unique_ptr<Request> &request : requests)
+        camera->queueRequest(request.get());
+
+    std::this_thread::sleep_for(1000ms);
+
+    camera->stop();
+    allocator->free(stream);
+    delete allocator;
+    camera->release();
+    camera.reset();
+    cm->stop();
+
+    return 0;
+}

--- a/src/drift-camera/CMakeLists.txt
+++ b/src/drift-camera/CMakeLists.txt
@@ -18,10 +18,12 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 add_compile_options(
     -lcamera
+    -ljpeg
 )
 
 # Use PkgConfig to link libcamera
 find_package(PkgConfig REQUIRED)
+find_package(JPEG REQUIRED)
 
 # Import libcamera libraries
 pkg_check_modules(LIBCAMERA REQUIRED IMPORTED_TARGET libcamera)
@@ -32,8 +34,10 @@ message(STATUS "    Include Path: ${LIBCAMERA_INCLUDE_DIRS}")
 
 # Add source files
 add_executable(drift-camera
-    ./src/camera.cpp
     ./src/drift_camera_main.cpp
+    ./src/camera.cpp
+    ./src/frame_buffer.cpp
+    ./src/logging.cpp
 )
 
 # Necesssary includes
@@ -41,6 +45,23 @@ target_include_directories(drift-camera PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     ${CMAKE_SOURCE_DIR}
     ${LIBCAMERA_INCLUDE_DIRS}
+    ${JPEG_INCLUDE_DIRS}
 )
 
 target_link_libraries(drift-camera PkgConfig::LIBCAMERA)
+target_link_libraries(drift-camera ${JPEG_LIBRARIES})
+
+# Add source files
+add_executable(test-script
+    ../../scripts/camera_test.cpp
+)
+
+# Necesssary includes
+target_include_directories(test-script PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    ${CMAKE_SOURCE_DIR}
+    ${LIBCAMERA_INCLUDE_DIRS}
+)
+
+target_link_libraries(test-script PkgConfig::LIBCAMERA)
+target_link_libraries(test-script ${JPEG_LIBRARIES})

--- a/src/drift-camera/include/camera.hpp
+++ b/src/drift-camera/include/camera.hpp
@@ -1,16 +1,83 @@
-#include <cstdint>
-#include <libcamera/libcamera.h>
-#include <memory>
+/**
+ * @file camera.hpp
+ * @brief Raspberry Pi GS Camera Manager for DRIFT Drone
+ */
 
+#pragma once
+
+#include <libcamera/libcamera.h>
+
+/**
+ * @class Camera
+ * @brief Abstracts the libcamera Camera class and manages interactions with
+ *      the camera
+ */
 class Camera {
   public:
+    /**
+     * @brief Initializes class members
+     */
     Camera();
-    ~Camera() = default;
 
+    /**
+     * @brief Releases and resets camera and related objects
+     */
+    ~Camera();
+
+    /**
+     * @brief Configures and starts the Raspberry Pi GS camera
+     *
+     * @note if camera is unable to be found and acquired the application will
+     *      exit
+     *
+     * @return 0
+     */
     int8_t start_camera();
 
+    /**
+     * @brief Change the configured camera parameter values
+     *
+     * @param width pixel width of image to receive from sensor
+     * @param height pixel height of image to receive from sensor
+     * @return true if camera is able to be configured with given parameters
+     * @return false if camera is unable to be configured with given parameters
+     */
+    bool change_config(uint16_t width, uint16_t height);
+
+    /**
+     * @brief Gets the actual camera device object
+     *
+     * @return libcamera Camera object representing the camera
+     */
+    std::shared_ptr<libcamera::Camera> get_camera();
+
+    /**
+     * @brief Gets the current configuration of the camera device object
+     * 
+     * @return libcamera CameraConfiguration object containing the camera
+     *      configuration
+     */
+    std::shared_ptr<libcamera::CameraConfiguration> get_config();
+
+    /**
+     * @brief Prints all found camera devices
+     */
     void print_cameras();
 
   private:
+    /**
+     * @brief The CameraManager runs for the lifetime of the application and is
+     *      responsible for abstracting the camera->application pipeline
+     */
     std::unique_ptr<libcamera::CameraManager> camera_manager;
+
+    /**
+     * @brief The actual camera; must be acquired by the CameraManger
+     */
+    std::shared_ptr<libcamera::Camera> camera;
+
+    /**
+     * @brief Represents the current configuration of the camera
+     */
+    std::shared_ptr<libcamera::CameraConfiguration> camera_config;
 };

--- a/src/drift-camera/include/frame_buffer.hpp
+++ b/src/drift-camera/include/frame_buffer.hpp
@@ -1,0 +1,75 @@
+/**
+ * @file frame_buffer.hpp
+ * @brief 
+ */
+
+#pragma once
+
+#include <libcamera/libcamera.h>
+#include <memory>
+
+#include "camera.hpp"
+
+/**
+ * @class FrameManager
+ * @brief Abstracts the libcamera FrameManager class and manages memory and
+ *      requests associated with receiving image frames from the camera
+ */
+class FrameManager {
+  public:
+    /**
+     * @brief Initializes the camera class member with the given camera object
+     *
+     * @param camera object containing relevant camera device and configuration
+     *      information
+     */
+    FrameManager(std::shared_ptr<Camera> camera);
+
+    /**
+     * @brief Releases the frame manager allocator used to manage memory
+     */
+    ~FrameManager();
+
+    /**
+     * @brief Allocates buffers for the camera
+     *
+     * @return 0 if buffers are successfully allocated; error value otherwise
+     */
+    int8_t setup_buffers();
+
+    /**
+     * @brief Creates a frame request for the camera
+     *
+     * @return 0 if the request is successfully created and added to the queue;
+     *      error value otherwise
+     */
+    int8_t create_request();
+
+    /**
+     * @brief Starts the camera and sends frame requests
+     *
+     * @return 0 if the camera is successfully started; error value otherwise
+     */
+    int8_t get_frame();
+
+    /**
+     * @brief Adds requests to the queue
+     */
+    void queue_requests();
+
+  private:
+    /**
+     * @brief Camera object containing the camera from which we will get images
+     */
+    std::shared_ptr<Camera> camera;
+
+    /**
+     * @brief Manages memory associated with frame buffers
+     */
+    std::unique_ptr<libcamera::FrameBufferAllocator> allocator;
+
+    /**
+     * @brief Manages image requests that will be sent to the camera
+     */
+    std::vector<std::unique_ptr<libcamera::Request>> requests;
+};

--- a/src/drift-camera/include/logging.hpp
+++ b/src/drift-camera/include/logging.hpp
@@ -1,0 +1,21 @@
+/**
+ * @file logging.hpp
+ * @brief Wrapped functions for logging messages to the console
+ */
+
+/**
+ * @brief Log message levels based on https://wiki.archlinux.org/title/Systemd/Journal
+ */
+enum log_level {
+    ERROR = 3,
+    INFO = 6
+};
+
+/**
+ * @brief Logs a message to the console (stdout/stderr depending on the message
+ *      level)
+ *
+ * @param level What level to log the message at
+ * @param format The message to log
+ */
+void log_message(log_level level, const char* format, ...);

--- a/src/drift-camera/src/camera.cpp
+++ b/src/drift-camera/src/camera.cpp
@@ -1,20 +1,113 @@
+/**
+ * @file camera.cpp
+ * @brief Implementation of Raspberry Pi GS Camera Manager for DRIFT Drone
+ */
 
-
+#include <cstdint>
+#include <cstdio>
+#include <libcamera/libcamera.h>
+#include <memory>
 
 #include "camera.hpp"
+#include "logging.hpp"
 
-Camera::Camera() : camera_manager(std::make_unique<libcamera::CameraManager>()) {}
+Camera::Camera() :
+    camera_manager(std::make_unique<libcamera::CameraManager>()),
+    camera(nullptr),
+    camera_config(nullptr)
+{}
+
+Camera::~Camera()
+{
+    camera->release();
+    camera_manager->stop();
+    camera.reset();
+    camera_config->end();
+}
 
 int8_t Camera::start_camera()
 {
     camera_manager->start();
 
+    print_cameras();
+
+    auto cameras = camera_manager->cameras();
+
+    if (cameras.empty()) {
+        log_message(ERROR, "Camera::start_camera(): Camera manager did not detect any camera devices");
+        camera_manager->stop();
+        exit(EXIT_FAILURE);
+    }
+
+    std::string camera_id = cameras[0]->id();
+
+    camera = camera_manager->get(camera_id);
+    if (camera == nullptr) {
+        log_message(ERROR, "Camera::start_camera(): Camera not found");
+        exit(EXIT_FAILURE);
+    }
+
+    camera->acquire();
+    if (camera == nullptr) {
+        log_message(ERROR, "Camera::start_camera(): Failed to acquire camera");
+        exit(EXIT_FAILURE);
+    }
+
+    camera_config = camera->generateConfiguration( { libcamera::StreamRole::Viewfinder } );
+    if (camera_config == nullptr) {
+        log_message(ERROR, "Camera::start_camera(): Failed to generate camera configuration");
+        exit(EXIT_FAILURE);
+    }
+
+    libcamera::StreamConfiguration &stream_config = camera_config->at(0);
+    log_message(INFO, "Camera::start_camera(): Default viewfinder configuration is: %s", stream_config.toString().c_str());
+
+    camera->configure(camera_config.get());
+
     return 0;
+}
+
+bool Camera::change_config(uint16_t width, uint16_t height)
+{
+    // Width = 800, Height = 600 is default values. If we want to change these
+    // values, we must verify the config before it gets applied to the camera
+    libcamera::StreamConfiguration &stream_config = camera_config->at(0);
+    stream_config.size.width = width;
+    stream_config.size.height = height;
+
+    switch (camera_config->validate()) {
+        case libcamera::CameraConfiguration::Valid:
+            log_message(INFO, "Camera::change_config(): New camera parameters successfully validated");
+            break;
+        case libcamera::CameraConfiguration::Adjusted:
+            log_message(INFO, "Camera::change_config(): New camera parameters adjusted successfully");
+            break;
+        case libcamera::CameraConfiguration::Invalid:
+            log_message(INFO, "Camera::change_config(): New camera parameters were not able to be applied");
+            return false;
+            break;
+        default:
+            break;
+    }
+
+    camera->configure(camera_config.get());
+
+    return true;
+}
+
+std::shared_ptr<libcamera::Camera> Camera::get_camera()
+{
+    return camera;
+}
+
+std::shared_ptr<libcamera::CameraConfiguration> Camera::get_config()
+{
+    return camera_config;
 }
 
 void Camera::print_cameras()
 {
     for (auto const &camera : camera_manager->cameras()) {
-        fprintf(stdout, "%s\n", camera->id());
+        log_message(INFO, "%s", camera->id().c_str());
     }
 }

--- a/src/drift-camera/src/drift_camera_main.cpp
+++ b/src/drift-camera/src/drift_camera_main.cpp
@@ -1,12 +1,34 @@
+/**
+ * @file drift_camera_main.cpp
+ * @brief Main running loop for drift-camera application
+ */
 
+#include <chrono>
+#include <libcamera/libcamera.h>
+#include <thread>
 
 #include "camera.hpp"
+#include "frame_buffer.hpp"
+#include "logging.hpp"
 
+std::shared_ptr<Camera> camera = std::make_shared<Camera>();
+
+/**
+ * @brief Main program loop for drift-camera application
+ */
 int main()
 {
-    Camera camera;
+    log_message(INFO, "main(): Starting drift-camera application");
+    camera->start_camera();
+    camera->print_cameras();
 
-    camera.print_cameras();
+    FrameManager frame_manager(camera);
+    frame_manager.setup_buffers();
+    frame_manager.create_request();
+    frame_manager.get_frame();
+    frame_manager.queue_requests();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
     return 0;
 }

--- a/src/drift-camera/src/frame_buffer.cpp
+++ b/src/drift-camera/src/frame_buffer.cpp
@@ -1,0 +1,202 @@
+/**
+ * @file frame_buffer.cpp
+ * @brief Responsible for sending requests for and receiving frames from the
+ *      Camera
+ */
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <jpeglib.h>
+#include <libcamera/libcamera.h>
+#include <memory>
+#include <sys/mman.h>
+#include <thread>
+#include <vector>
+
+#include "frame_buffer.hpp"
+#include "logging.hpp"
+
+// The camera object from main that allows us to requeue requests from the
+// callback function
+extern std::shared_ptr<Camera> camera;
+
+// One byte each for R, G, and B
+constexpr uint8_t NUM_COMPONENTS_RGB = 3u;
+// One byte each for X, R, G, and B
+constexpr uint8_t NUM_COMPONENTS_XRGB = 4u;
+// Quality ranges from 0-100
+constexpr uint8_t JPEG_QUALITY = 100u;
+
+/**
+ * @brief Allows for camera frames to be saved to disk as a JPEG image
+ *
+ * @param data buffer containing camera image data
+ * @param width pixel width of the image
+ * @param height pixel height of the image
+ * @param filename Where to save the JPEG image to
+ */
+void save_jpeg_image(const uint8_t *data, int32_t width, int32_t height, const std::string &filename)
+{
+    struct jpeg_compress_struct compression_info;
+    struct jpeg_error_mgr jpeg_error;
+    compression_info.err = jpeg_std_error(&jpeg_error);
+    jpeg_create_compress(&compression_info);
+
+    std::FILE *outfile = fopen(filename.c_str(), "wb");
+    if (!outfile) {
+        log_message(ERROR, "Failed to open file for writing: %s", filename.c_str());
+        return;
+    }
+
+    jpeg_stdio_dest(&compression_info, outfile);
+    compression_info.image_width = width;
+    compression_info.image_height = height;
+    compression_info.input_components = NUM_COMPONENTS_RGB;
+    compression_info.in_color_space = JCS_RGB;
+    jpeg_set_defaults(&compression_info);
+    jpeg_set_quality(&compression_info, JPEG_QUALITY, TRUE);
+    jpeg_start_compress(&compression_info, TRUE);
+
+    std::vector<uint8_t> rgb_data(width * height * NUM_COMPONENTS_RGB);
+    for (int i = 0; i < width * height; i++) {
+        rgb_data[i * NUM_COMPONENTS_RGB + 0] = data[i * NUM_COMPONENTS_XRGB + 2];  // R
+        rgb_data[i * NUM_COMPONENTS_RGB + 1] = data[i * NUM_COMPONENTS_XRGB + 1];  // G
+        rgb_data[i * NUM_COMPONENTS_RGB + 2] = data[i * NUM_COMPONENTS_XRGB + 0];  // B
+    }
+
+    while (compression_info.next_scanline < compression_info.image_height) {
+        JSAMPROW row_pointer = (JSAMPROW)&rgb_data[compression_info.next_scanline * width * NUM_COMPONENTS_RGB];
+        jpeg_write_scanlines(&compression_info, &row_pointer, 1);
+    }
+
+    jpeg_finish_compress(&compression_info);
+    jpeg_destroy_compress(&compression_info);
+    fclose(outfile);
+}
+
+/**
+ * @brief Remaps the image frame plane into a data buffer
+ *
+ * @param plane image plane to remap
+ */
+static void *map_frame_buffer(const libcamera::FrameBuffer::Plane &plane)
+{
+    void *mapped_memory = mmap(nullptr, plane.length, PROT_READ | PROT_WRITE, MAP_SHARED, plane.fd.get(), plane.offset);
+    if (mapped_memory == MAP_FAILED) {
+        log_message(ERROR, "Failed to map memory");
+        return nullptr;
+    }
+    return mapped_memory;
+}
+
+/**
+ * @brief Callback function the libcamera Camera object will use to place image
+ *      frames into the buffer
+ *
+ * @param request camera frame request that was sent to the camera
+ */
+static void request_complete(libcamera::Request *request)
+{
+    if (request->status() == libcamera::Request::RequestCancelled) {
+        log_message(ERROR, "FrameManager::request_complete(): Frame request was cancelled");
+        return;
+    } else if (request->status() == libcamera::Request::RequestPending) {
+        log_message(ERROR, "FrameManager::request_complete(): Frame request still pending");
+        return;
+    } else if (request->status() != libcamera::Request::RequestComplete) {
+        log_message(ERROR, "FrameManager::request_complete(): Frame request incomplete");
+        return;
+    }
+
+    const std::map<const libcamera::Stream *, libcamera::FrameBuffer *> &buffers = request->buffers();
+
+    for (auto buffer_pair : buffers) {
+        libcamera::FrameBuffer *buffer = buffer_pair.second;
+        const libcamera::FrameMetadata &metadata = buffer->metadata();
+
+        for (const libcamera::FrameMetadata::Plane &frame_plane : metadata.planes()) {
+            log_message(INFO, "FrameManager::request_complete(): Metadata sequence %u; Bytes used: %u", metadata.sequence, frame_plane.bytesused);
+        }
+        libcamera::FrameBuffer::Plane plane = buffer->planes().at(0);
+
+        void *data = map_frame_buffer(plane);
+
+        const uint8_t *pixel_data = static_cast<const uint8_t *>(data);
+        int width = 800;
+        int height = 600;
+
+        std::string filename = "image1.jpg";
+        save_jpeg_image(pixel_data, width, height, filename);
+    }
+
+    request->reuse(libcamera::Request::ReuseBuffers);
+    camera->get_camera()->queueRequest(request);
+}
+
+FrameManager::FrameManager(std::shared_ptr<Camera> camera) : camera(camera)
+{
+}
+
+FrameManager::~FrameManager()
+{
+    allocator->free(camera->get_config()->at(0).stream());
+}
+
+int8_t FrameManager::setup_buffers()
+{
+    allocator = std::unique_ptr<libcamera::FrameBufferAllocator>(new libcamera::FrameBufferAllocator(camera->get_camera()));
+    for (libcamera::StreamConfiguration &stream_config : *camera->get_config()) {
+        int8_t ret = allocator->allocate(stream_config.stream());
+        if (ret < 0) {
+            log_message(ERROR, "FrameManager::setup_buffers(): Buffer allocation failed");
+            return -ENOMEM;
+        }
+
+        size_t allocated = allocator->buffers(stream_config.stream()).size();
+        log_message(INFO, "FrameManager::setup_buffers(): Allocated %zu buffers for stream", allocated);
+    }
+
+    return 0;
+}
+
+int8_t FrameManager::create_request()
+{
+    libcamera::Stream *stream = camera->get_config()->at(0).stream();
+    const std::vector<std::unique_ptr<libcamera::FrameBuffer>> &buffers = allocator->buffers(stream);
+
+    for (uint32_t i = 0; i < buffers.size(); ++i) {
+        std::unique_ptr<libcamera::Request> request = camera->get_camera()->createRequest();
+        if (!request) {
+            log_message(ERROR, "FrameManager::create_request(): Failed to create frame request");
+            return -ENOMEM;
+        }
+
+        const std::unique_ptr<libcamera::FrameBuffer> &buffer = buffers[1];
+        int8_t ret = request->addBuffer(stream, buffer.get());
+        if (ret < 0) {
+            log_message(ERROR, "FrameManager::create_request(): Can't create buffer for request");
+            return ret;
+        }
+
+        requests.push_back(std::move(request));
+    }
+
+    return 0;
+}
+
+int8_t FrameManager::get_frame()
+{
+    camera->get_camera()->requestCompleted.connect(request_complete);
+    camera->get_camera()->start();
+    return 0;
+}
+
+void FrameManager::queue_requests()
+{
+    for (std::unique_ptr<libcamera::Request> &request : requests) {
+        camera->get_camera()->queueRequest(request.get());
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+}

--- a/src/drift-camera/src/logging.cpp
+++ b/src/drift-camera/src/logging.cpp
@@ -1,0 +1,56 @@
+/**
+ * @file logging.cpp
+ * @brief Wrapped functions for logging messages to the console
+ */
+
+#include <cstdio>
+#include <cstdarg>
+#include <ctime>
+
+#include "logging.hpp"
+
+/**
+ * @brief Gets and formats the current timestamp
+ *
+ * @return C-string containing the formatted timestamp
+ */
+static const char* get_current_timestamp()
+{
+    static char timestamp_buffer[20];
+    std::time_t current_time = std::time(nullptr);
+    std::strftime(timestamp_buffer, sizeof(timestamp_buffer), "%Y-%m-%d %H:%M:%S", std::localtime(&current_time));
+    return timestamp_buffer;
+}
+
+/**
+ * @brief Converts the enum log level into a tag string
+ *
+ * @param level Log message level to convert
+ * @return C-string containing the message level as a string
+ */
+static const char* log_level_to_string(log_level level)
+{
+    switch (level) {
+    case ERROR:
+        return "ERROR";
+    case INFO:
+        return "INFO";
+    default:
+        return "NONE";
+    }
+}
+
+void log_message(log_level level, const char* format, ...)
+{
+    char message_buffer[1024];
+
+    va_list args;
+    va_start(args, format);
+    vsnprintf(message_buffer, sizeof(message_buffer), format, args);
+    va_end(args);
+
+    std::FILE* output = (level == ERROR) ? stderr : stdout;
+
+    fprintf(output, "[%s] [%s] - %s\n", get_current_timestamp(), log_level_to_string(level), message_buffer);
+    fflush(output);
+}


### PR DESCRIPTION
## Problem

In a previous task, we connected and configured our Raspberry Pi Global Shutter Camera to verify that we were able to receive data from our camera. Now that we know the camera is working, we need to be able to get image frames from the camera in a program-usable format, so that our `CV` algorithm can run on the data that the camera sees.

## Solution

Design a base camera application to verify that we can properly interact with and receive images from the camera.

## Testing

On-device runs; a test image is saved as "image1.jpg".

Issue: https://github.com/ameall/drift-fw/issues/9