### PR TITLE
Issue 46: Switch from NED to Body-Relative Control

### DIFF
--- a/apps/drift-control/src/drift_control_main.py
+++ b/apps/drift-control/src/drift_control_main.py
@@ -5,7 +5,7 @@
 
 import asyncio
 from mavsdk import System
-from mavsdk.offboard import (OffboardError, VelocityNedYaw)
+from mavsdk.offboard import (OffboardError, VelocityBodyYawspeed)
 
 from drone_controller import DroneController
 from log import logger
@@ -14,7 +14,7 @@ from server import UnixSocketServer
 
 
 async def run():
-    """ Does Offboard control using velocity NED coordinates. """
+    """ Does Offboard control using velocity body coordinates. """
     # ======= Camera App Simulator ======= #
     # controller = DroneController()
     # server = UnixSocketServer()
@@ -55,7 +55,7 @@ async def run():
     await asyncio.sleep(15)
 
     logger.info("-- Setting initial setpoint")
-    await drone.offboard.set_velocity_ned(VelocityNedYaw(0.0, 0.0, 0.0, 0.0))
+    await drone.offboard.set_velocity_body(VelocityBodyYawspeed(0.0, 0.0, 0.0, 0.0))
 
     logger.info("-- Starting offboard")
     try:
@@ -68,11 +68,11 @@ async def run():
         return
 
     logger.info("-- Go up 1 m/s")
-    await drone.offboard.set_velocity_ned(VelocityNedYaw(0.0, 0.0, -1.0, 0.0))
+    await drone.offboard.set_velocity_body(VelocityBodyYawspeed(0.0, 0.0, -1.0, 0.0))
     await asyncio.sleep(4)
 
     logger.info("-- Hold position for 2s")
-    await drone.offboard.set_velocity_ned(VelocityNedYaw(0.0, 0.0, 0.0, 0.0))
+    await drone.offboard.set_velocity_body(VelocityBodyYawspeed(0.0, 0.0, 0.0, 0.0))
     await asyncio.sleep(3)
 
     while True:
@@ -80,7 +80,7 @@ async def run():
         x, y, area = server.extract_values_from_message()
         right, fwd, up = controller.compute_velocity(area, x, y)
         logger.info(f"Velocity fwd: {fwd}, up: {up}, right: {right}")
-        await drone.offboard.set_velocity_ned(VelocityNedYaw(fwd, right, up, 0))
+        await drone.offboard.set_velocity_body(VelocityBodyYawspeed(fwd, right, up, 0))
 
     logger.info("-- Stopping offboard")
     try:


### PR DESCRIPTION
### Problem

We currently use a MavSDK function, `set_velocity_ned()`, to manage the flight of our drone. This function is compass-based, which means that our drone will always aim towards the North, as we currently don't rotate the drone during flight, meaning that we restrict ourselves to traveling in the North direction. The more ideal solution is to set velocities relative to the direction the drone body is pointed, which can be accomplished via the `set_velocity_body()` function.

### Solution

Update `drift_control_main.py` to use the `set_velocity_body()` function instead of the `set_velocity_ned()` function.

### Testing

Output print testing.

Issue: https://github.com/ameall/drift-fw/issues/46