### PR TITLE
Issue 34: BUG: Model Reallocation On Every Frame (#34)

### DIFF
--- a/apps/drift-camera/src/drift_camera_main.cpp
+++ b/apps/drift-camera/src/drift_camera_main.cpp
@@ -7,10 +7,11 @@
 #include "frame_buffer.hpp"
 #include "logging.hpp"
 // #include "message.hpp"
-// #include "model.hpp"
+ #include "model.hpp"
 // #include "socket.hpp"
 
 std::shared_ptr<Camera> camera = std::make_shared<Camera>();
+std::shared_ptr<Model> camera = std::make_shared<Model>();
 
 /**
  * @brief Main program loop for drift-camera application

--- a/apps/drift-camera/src/frame_buffer.cpp
+++ b/apps/drift-camera/src/frame_buffer.cpp
@@ -18,6 +18,9 @@
 #include "model.hpp"
 
 extern std::shared_ptr<Camera> camera;
+extern std::shared_ptr<Model> model;
+
+// int32_t count = 0;
 
 /**
  * @brief Callback function the libcamera Camera object will use to place image
@@ -27,7 +30,6 @@ extern std::shared_ptr<Camera> camera;
  */
 static void request_complete(libcamera::Request *request)
 {
-    Model model;
     if (request->status() == libcamera::Request::RequestCancelled) {
         log_message(ERROR, "FrameManager::request_complete(): Frame request was cancelled");
         return;
@@ -62,11 +64,14 @@ static void request_complete(libcamera::Request *request)
         const uint8_t *xrgb_image_data = map_frame_buffer(plane);
         std::vector<uint8_t> rgb_data = convert_xrgb_to_rgb(xrgb_image_data, DEFAULT_CAMERA_WIDTH, DEFAULT_CAMERA_HEIGHT);
         cv::Mat image(DEFAULT_CAMERA_HEIGHT, DEFAULT_CAMERA_WIDTH, CV_8UC3, rgb_data.data());
-        model.process_frame(image);
+        model->process_frame(image);
     }
 
     request->reuse(libcamera::Request::ReuseBuffers);
     camera->get_camera()->queueRequest(request);
+    // FPS tracking
+    // log_message(INFO, "%d", count);
+    // count++;
 }
 
 FrameManager::FrameManager(std::shared_ptr<Camera> camera) : camera(camera)


### PR DESCRIPTION
## Problem

It was recently discovered that the camera app allocates and frees the CV model on every instance of the callback function, which results in unnecessary memory operations. This also have the unintended consequence of disconnecting and reconnecting the UNIX socket for every frame.

## Task

Modified the camera app CV model/frame request callback function to not reallocate the model on every frame.

## Testing

On-drone testing

Issue: https://github.com/ameall/drift-fw/issues/34