### PR TITLE
Issue 43: PID Deadzone and Flight Test Changes (#43)

### DIFF
--- a/apps/drift-camera/src/drift_camera_main.cpp
+++ b/apps/drift-camera/src/drift_camera_main.cpp
@@ -11,7 +11,6 @@
 // #include "socket.hpp"
 
 std::shared_ptr<Camera> camera = std::make_shared<Camera>();
-std::shared_ptr<Model> model = std::make_shared<Model>();
 
 /**
  * @brief Main program loop for drift-camera application

--- a/apps/drift-camera/src/frame_buffer.cpp
+++ b/apps/drift-camera/src/frame_buffer.cpp
@@ -32,6 +32,7 @@ BufferManager buffer_manager;
 static void request_complete(libcamera::Request *request)
 {
     Model model;
+
     if (request->status() == libcamera::Request::RequestCancelled) {
         log_message(ERROR, "FrameManager::request_complete(): Frame request was cancelled");
         return;

--- a/apps/drift-camera/src/model.cpp
+++ b/apps/drift-camera/src/model.cpp
@@ -79,8 +79,8 @@ void Model::process_frame(cv::Mat frame)
 
     detected_boxes = process_outputs(frame, outputs, class_values);
 
-    draw_bounding_boxes(frame, detected_boxes, class_names, class_values);
-    cv::imshow("Frame", frame);
+    // draw_bounding_boxes(frame, detected_boxes, class_names, class_values);
+    // cv::imshow("Frame", frame);
 }
 
 bool Model::end_processing() const

--- a/apps/drift-camera/src/socket.cpp
+++ b/apps/drift-camera/src/socket.cpp
@@ -80,6 +80,8 @@ bool SocketManager::send_message(OutputsMessage &message)
 
 bool SocketManager::close_socket()
 {
+    log_message(INFO, "SocketManager::close_socket(): Closing socket");
+
     if (socket_fd == -1) {
         log_message(INFO, "SocketManager::close_socket(): No socket is open");
         return true;

--- a/apps/drift-control/src/drift_control_main.py
+++ b/apps/drift-control/src/drift_control_main.py
@@ -4,6 +4,7 @@
 """
 
 import asyncio
+import time
 from mavsdk import System
 from mavsdk.offboard import (OffboardError, VelocityBodyYawspeed)
 
@@ -16,21 +17,22 @@ from server import UnixSocketServer
 async def run():
     """ Does Offboard control using velocity body coordinates. """
     # ======= Camera App Simulator ======= #
-    controller = DroneController()
-    server = UnixSocketServer()
-    server.start_server()
-    while True:
-        server.accept_client()
-        x, y, area = server.extract_values_from_message()
-        fwd, up, right = controller.compute_velocity(area, x, y)
-        logger.info("");
-        logger.info(f"Velocity fwd: {fwd}, up: {up}, right: {right}")
-        logger.info("");
+    # controller = DroneController()
+    # server = UnixSocketServer()
+    # server.start_server()
+    # while True:
+    #     server.accept_client()
+    #     x, y, area = server.extract_values_from_message()
+    #     fwd, up, right = controller.compute_velocity(area, x, y)
+    #     logger.info("");
+    #     logger.info(f"Velocity fwd: {fwd}, up: {up}, right: {right}")
+    #     logger.info("");
 
     # ======= Main Flight Loop ======= #
     drone = System()
     controller = DroneController()
     server = UnixSocketServer()
+    server.start_server()
     simulator = CameraAppSimulator()
     # Use system address serial port for actual drone
     await drone.connect("serial:///dev/ttyAMA0:921600")
@@ -69,18 +71,28 @@ async def run():
 
     logger.info("-- Go up 1 m/s")
     await drone.offboard.set_velocity_body(VelocityBodyYawspeed(0.0, 0.0, -1.0, 0.0))
-    await asyncio.sleep(4)
+    await asyncio.sleep(6)
 
     logger.info("-- Hold position for 2s")
     await drone.offboard.set_velocity_body(VelocityBodyYawspeed(0.0, 0.0, 0.0, 0.0))
     await asyncio.sleep(3)
 
+    x_velocity = 0
     while True:
         server.accept_client()
         x, y, area = server.extract_values_from_message()
         right, fwd, up = controller.compute_velocity(area, x, y)
-        logger.info(f"Velocity fwd: {fwd}, up: {up}, right: {right}")
-        await drone.offboard.set_velocity_body(VelocityBodyYawspeed(fwd, right, up, 0))
+        logger.info(f"Setting velocity fwd: {fwd}, up: {up}, right: {right}")
+        if (x_velocity - right > 0):
+            while (x_velocity - right > 0):
+                x_velocity = x_velocity - 0.2
+                await drone.offboard.set_velocity_body(VelocityBodyYawspeed(fwd, x_velocity, -0.05, 0))
+                time.sleep(0.05)
+        if (x_velocity - right < 0):
+            while (x_velocity - right < 0):
+                x_velocity = x_velocity + 0.2
+                await drone.offboard.set_velocity_body(VelocityBodyYawspeed(fwd, x_velocity, -0.05, 0))
+                time.sleep(0.05)
 
     logger.info("-- Stopping offboard")
     try:

--- a/apps/drift-control/src/drone_controller.py
+++ b/apps/drift-control/src/drone_controller.py
@@ -21,15 +21,15 @@ from typing import Final
 from pixel_displacement_simulator import CameraAppSimulator
 
 
-DEFAULT_PROP_GAIN_X: Final[float] = 0
+DEFAULT_PROP_GAIN_X: Final[float] = 0.05
 DEFAULT_PROP_GAIN_Y: Final[float] = 0
 DEFAULT_PROP_GAIN_Z: Final[float] = 0
 
-DEFAULT_INT_GAIN_X: Final[int] = 0
-DEFAULT_INT_GAIN_Y: Final[int] = 0
-DEFAULT_INT_GAIN_Z: Final[int] = 0
+DEFAULT_INT_GAIN_X: Final[float] = 0
+DEFAULT_INT_GAIN_Y: Final[float] = 0
+DEFAULT_INT_GAIN_Z: Final[float] = 0
 
-DEFAULT_DER_GAIN_X: Final[float] = 0
+DEFAULT_DER_GAIN_X: Final[float] = 0.05
 DEFAULT_DER_GAIN_Y: Final[float] = 0
 DEFAULT_DER_GAIN_Z: Final[float] = 0
 
@@ -37,7 +37,7 @@ INITIAL_TARGET_AREA: Final[int] = 2000
 MAX_AREA_GROWTH: Final[int] = 100
 
 MAX_VELOCITY: Final[int] = 2
-MAX_ACCELERATION: Final[float] = 0.4
+MAX_ACCELERATION: Final[float] = 10.0
 
 DAMPING_FACTOR: Final[float] = 0.02
 MAX_INTEGRAL: Final[int] = 1000
@@ -81,6 +81,11 @@ class DroneController:
         def clamp(value, max_value, min_value):
             return max(min(value, max_value), min_value)
 
+        if x_error > 50:
+            x_error -= 50
+        if x_error < 50:
+            x_error += 50
+
         # Dynamic area growth adjustment with damping
         area_error = self.target_area - area
         area_growth_rate = min(self.max_area_growth, abs(area_error) * DAMPING_FACTOR)
@@ -118,6 +123,9 @@ class DroneController:
         self.prev_x_error = x_error
         self.prev_y_error = y_error
         self.prev_z_error = area_error
+
+        if x_error < 50 and x_error > -50:
+            x_velocity = 0
 
         return x_velocity, y_velocity, z_velocity
 

--- a/apps/drift-control/src/server.py
+++ b/apps/drift-control/src/server.py
@@ -86,8 +86,9 @@ class UnixSocketServer:
         data = self.client_connection.recv(OUTPUT_MESSAGE_SIZE)
 
         if not data:
-            self.client_connection.close()
-            logger.info("UnixSocketServer::get_message_from_client(): Client connection closed")
+            # self.client_connection.close()
+            # logger.info("UnixSocketServer::get_message_from_client(): Client connection closed")
+            pass
 
         try:
             json_data = json.loads(data.decode('utf-8'))


### PR DESCRIPTION
## Problem

We recently tested our PID loop in flight. While results were promising, extreme oscillations were observed, both due to an untuned PID loop and our acceleration cap. For multiple reasons, the need was identified to have a "PID deadzone" at the center of our image frame, where detection centers in this region would not affect the velocity.

## Solution

Implement a PID deadzone at the center of the image frame to prevent our PID loop from attempting to make constant microcorrections.

## Testing

Flight testing.

Issue: https://github.com/ameall/drift-fw/issues/43