### PR TITLE
Issue 53: Save Camera Frames and Detections (#53)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "fstream": "cpp",
+        "iosfwd": "cpp",
+        "vector": "cpp"
+    }
+}

--- a/apps/drift-camera/include/buffer_manager.hpp
+++ b/apps/drift-camera/include/buffer_manager.hpp
@@ -1,6 +1,6 @@
 /**
  * @file buffer_manager.hpp
- * @brief 
+ * @brief BufferManager class declaration
  */
 
 #include <cstdint>
@@ -8,8 +8,23 @@
 
 #include <unordered_map>
 
+/**
+ * @class BufferManager
+ * @brief Abstracts management of the buffers used to store images captured
+ *      from the camera
+ */
 class BufferManager {
   public:
+    BufferManager() = default;
+
+    ~BufferManager() = default;
+
+    // Deleting copy and move constructors
+    BufferManager(const BufferManager&) = delete;
+    BufferManager& operator=(const BufferManager&) = delete;
+    BufferManager(BufferManager&&) = delete;
+    BufferManager& operator=(BufferManager&&) = delete;
+
     /**
      * @brief Maps buffers to file descriptors and stored them in a map so that
      *      they don't have to be remapped on each use
@@ -26,6 +41,9 @@ class BufferManager {
      */
     uint8_t* get_buffer(libcamera::FrameBuffer *buffer) const noexcept;
 
+    /**
+     * @brief Clears all buffer mappings
+     */
     void unmap_all();
 
   private:

--- a/apps/drift-camera/include/camera.hpp
+++ b/apps/drift-camera/include/camera.hpp
@@ -1,6 +1,6 @@
 /**
  * @file camera.hpp
- * @brief Raspberry Pi GS Camera Manager for DRIFT Drone
+ * @brief Raspberry Pi GS Camera class declaration
  */
 
 #pragma once
@@ -25,6 +25,7 @@ class Camera {
      */
     ~Camera();
 
+    // Deleting copy and move constructors
     Camera(const Camera&) = delete;
     Camera& operator=(const Camera&) = delete;
     Camera(Camera&&) = delete;
@@ -71,19 +72,7 @@ class Camera {
     void print_cameras() const noexcept;
 
   private:
-    /**
-     * @brief The CameraManager runs for the lifetime of the application and is
-     *      responsible for abstracting the camera->application pipeline
-     */
     std::unique_ptr<libcamera::CameraManager> camera_manager;
-
-    /**
-     * @brief The actual camera; must be acquired by the CameraManger
-     */
     std::shared_ptr<libcamera::Camera> camera;
-
-    /**
-     * @brief Represents the current configuration of the camera
-     */
     std::shared_ptr<libcamera::CameraConfiguration> camera_config;
 };

--- a/apps/drift-camera/include/frame_buffer.hpp
+++ b/apps/drift-camera/include/frame_buffer.hpp
@@ -1,7 +1,6 @@
 /**
  * @file frame_buffer.hpp
- * @brief Responsible for managing memory associated with sending requests for
- *      and receiving frames from the camera
+ * @brief FrameManager class declaration
  */
 
 #pragma once
@@ -32,6 +31,12 @@ class FrameManager {
      */
     ~FrameManager();
 
+    // Deleting copy and move constructors
+    FrameManager(const FrameManager&) = delete;
+    FrameManager& operator=(const FrameManager&) = delete;
+    FrameManager(FrameManager&&) = delete;
+    FrameManager& operator=(FrameManager&&) = delete;
+
     /**
      * @brief Allocates buffers for the camera
      *
@@ -49,29 +54,11 @@ class FrameManager {
 
     /**
      * @brief Starts the camera and sends frame requests
-     *
-     * @return 0 if the camera is successfully started; error value otherwise
      */
-    int8_t get_frame();
-
-    /**
-     * @brief Adds requests to the queue
-     */
-    void queue_requests();
+    void get_frames();
 
   private:
-    /**
-     * @brief Camera object containing the camera from which we will get images
-     */
     std::shared_ptr<Camera> camera;
-
-    /**
-     * @brief Manages memory associated with frame buffers
-     */
     std::unique_ptr<libcamera::FrameBufferAllocator> allocator;
-
-    /**
-     * @brief Manages image requests that will be sent to the camera
-     */
     std::vector<std::unique_ptr<libcamera::Request>> requests;
 };

--- a/apps/drift-camera/include/logging.hpp
+++ b/apps/drift-camera/include/logging.hpp
@@ -1,6 +1,6 @@
 /**
  * @file logging.hpp
- * @brief Wrapped functions for logging messages to the console
+ * @brief Logging function declarations
  */
 
 /**

--- a/apps/drift-camera/include/message.hpp
+++ b/apps/drift-camera/include/message.hpp
@@ -1,7 +1,6 @@
 /**
  * @file message.hpp
- * @brief JSON message manager for sending camera image processing outputs from
- *      this camera app to the flight control app
+ * @brief OutputsMessage class declaration
  */
 
 #pragma once
@@ -12,13 +11,26 @@
 
 using nlohmann::json;
 
+/**
+ * @class OutputsMessage
+ * @brief Manages the messages sent by the camera application to the flight
+ *      control application
+ *
+ */
 class OutputsMessage {
   public:
     /**
      * @brief Creates a JSON message object
      */
     explicit OutputsMessage();
+
     ~OutputsMessage() = default;
+
+    // Deleting copy and move constructors
+    OutputsMessage(const OutputsMessage&) = delete;
+    OutputsMessage& operator=(const OutputsMessage&) = delete;
+    OutputsMessage(OutputsMessage&&) = delete;
+    OutputsMessage& operator=(OutputsMessage&&) = delete;
 
     /**
      * @brief Creates a JSON message to send over the socket
@@ -35,24 +47,23 @@ class OutputsMessage {
     /**
      * @brief Clears the json message and resets the valid flag
      */
-    void clear_message();
+    void clear_message() noexcept;
 
     /**
      * @brief Returns the message as a string instead of a JSON object
      *
      * @return string-ified JSON message
      */
-    std::string get_message_as_string() const;
+    std::string get_message_as_string() const noexcept;
 
     /**
      * @brief Returns whether the JSON message is valid
      *
      * @return true if the message is valid; false otherwise
      */
-    bool is_message_valid() const;
+    bool is_message_valid() const noexcept;
 
   private:
     bool message_valid;
-
     json message;
 };

--- a/apps/drift-camera/include/model.hpp
+++ b/apps/drift-camera/include/model.hpp
@@ -1,7 +1,6 @@
 /**
  * @file model.hpp
- * @brief Defines the CV model class that will be used for camera image
- *      processing
+ * @brief Model class declaration
  */
 
 #pragma once
@@ -45,7 +44,14 @@ struct detection {
 class Model {
   public:
     explicit Model();
+
     ~Model() = default;
+
+    // Deleting copy and move constructors
+    Model(const Model&) = delete;
+    Model& operator=(const Model&) = delete;
+    Model(Model&&) = delete;
+    Model& operator=(Model&&) = delete;
 
     /**
      * @brief Configures the CV model based on a provided .onnx file, or .cfg/
@@ -78,6 +84,9 @@ class Model {
      */
     bool end_processing() const;
 
+    /**
+     * @brief Test function to allow us to run the model on a saved .mp4 video
+     */
     void process_mp4(const std::string);
 
     // Function to process network outputs and return the bounding boxes after NMS
@@ -129,7 +138,7 @@ class Model {
     std::map<int32_t, detection> new_tracked_boxes;
     int32_t next_id;
 
-    // Results senidng objects
+    // Results sending objects
     SocketManager socket;
     OutputsMessage message;
     int32_t message_id;

--- a/apps/drift-camera/include/socket.hpp
+++ b/apps/drift-camera/include/socket.hpp
@@ -1,7 +1,6 @@
 /**
  * @file socket.hpp
- * @brief Socket manager for sending a structured message from this camera app
- *      to the flight control app
+ * @brief SocketManager class declaration
  */
 
 #pragma once
@@ -15,6 +14,11 @@
 
 const std::string DEFAULT_SOCKET_NAME = "DRIFT.sock";
 
+/**
+ * @class SocketManager
+ * @brief Manages the UNIX socket for sending extracted detection info from the
+ *      camera application to the flight control application
+ */
 class SocketManager {
   public:
     /**
@@ -29,6 +33,12 @@ class SocketManager {
      *      scope
      */
     ~SocketManager();
+
+    // Deleting copy and move constructors
+    SocketManager(const SocketManager&) = delete;
+    SocketManager& operator=(const SocketManager&) = delete;
+    SocketManager(SocketManager&&) = delete;
+    SocketManager& operator=(SocketManager&&) = delete;
 
     /**
      * @brief Creates the actual socket and connects to the server
@@ -54,8 +64,6 @@ class SocketManager {
 
   private:
     int32_t socket_fd;
-
     std::string socket_path;
-
     struct sockaddr_un socket_address;
 };

--- a/apps/drift-camera/src/buffer_manager.cpp
+++ b/apps/drift-camera/src/buffer_manager.cpp
@@ -1,6 +1,6 @@
 /**
  * @file buffer_manager.cpp
- * @brief 
+ * @brief Manages the frames for capturing images from the camera
  */
 
 #include <cstdio>

--- a/apps/drift-camera/src/drift_camera_main.cpp
+++ b/apps/drift-camera/src/drift_camera_main.cpp
@@ -6,9 +6,6 @@
 #include "camera.hpp"
 #include "frame_buffer.hpp"
 #include "logging.hpp"
-// #include "message.hpp"
- #include "model.hpp"
-// #include "socket.hpp"
 
 std::shared_ptr<Camera> camera = std::make_shared<Camera>();
 
@@ -17,26 +14,6 @@ std::shared_ptr<Camera> camera = std::make_shared<Camera>();
  */
 int main()
 {
-    // Socket test
-    // SocketManager socket_manager;
-    // socket_manager.initialize_socket();
-    // OutputsMessage message;
-    // while (true) {
-    //     message.create_message(1, 20000, 500, -500);
-    //     socket_manager.send_message(message);
-    //     message.clear_message();
-    // }
-
-    // return 0;
-
-    // CV model test
-    // Model model;
-    // const std::string path_to_video = "/home/mealla/Documents/GitHub/drift-tracking/videos/IMG_4220.mp4";
-    // const std::string path_to_video = "/home/drift/drift-tracking/videos/IMG_4220.mp4";
-    // model.process_mp4(path_to_video);
-
-    // return 0;
-
     log_message(INFO, "main(): Starting drift-camera application");
 
     camera->start_camera();
@@ -45,12 +22,9 @@ int main()
     FrameManager frame_manager(camera);
     frame_manager.setup_buffers();
     frame_manager.create_request();
-    frame_manager.get_frame();
-    frame_manager.queue_requests();
+    frame_manager.get_frames();
 
-    while (1) {
-        // Need to add logic to allow flight control app to tell camera app to stop
-    }
+    while (1) {}
 
     return 0;
 }

--- a/apps/drift-camera/src/frame_buffer.cpp
+++ b/apps/drift-camera/src/frame_buffer.cpp
@@ -4,12 +4,10 @@
  *      and receiving frames from the camera
  */
 
-#include <chrono>
 #include <cstdio>
 #include <jpeglib.h>
 #include <opencv2/opencv.hpp>
 #include <sys/mman.h>
-#include <thread>
 #include <vector>
 
 #include "buffer_manager.hpp"
@@ -19,9 +17,7 @@
 
 extern std::shared_ptr<Camera> camera;
 
-BufferManager buffer_manager;
-
-// int32_t count = 0;
+static BufferManager buffer_manager;
 
 /**
  * @brief Callback function the libcamera Camera object will use to place image
@@ -33,15 +29,8 @@ static void request_complete(libcamera::Request *request)
 {
     Model model;
 
-    if (request->status() == libcamera::Request::RequestCancelled) {
-        log_message(ERROR, "FrameManager::request_complete(): Frame request was cancelled");
-        return;
-    } else if (request->status() == libcamera::Request::RequestPending) {
-        log_message(ERROR, "FrameManager::request_complete(): Frame request still pending");
-        return;
-    } else if (request->status() != libcamera::Request::RequestComplete) {
-        log_message(ERROR, "FrameManager::request_complete(): Frame request incomplete");
-        return;
+    if (request->status() != libcamera::Request::RequestComplete) {
+        log_message(ERROR, "request_complete(): Frame request was not completed");
     }
 
     for (auto &[stream, buffer] : request->buffers()) {
@@ -55,20 +44,14 @@ static void request_complete(libcamera::Request *request)
         cv::Mat xrgb_image(camera->get_config()->at(0).size.height, camera->get_config()->at(0).size.width, CV_8UC4, xrgb_data);
         cv::Mat rgb_image;
         cv::cvtColor(xrgb_image, rgb_image, cv::COLOR_BGRA2BGR);
-        cv::imwrite("image.jpg", rgb_image);
         model.process_frame(rgb_image);
     }
 
     request->reuse(libcamera::Request::ReuseBuffers);
     camera->get_camera()->queueRequest(request);
-    // FPS tracking
-    // log_message(INFO, "%d", count);
-    // count++;
 }
 
-FrameManager::FrameManager(std::shared_ptr<Camera> camera) : camera(camera)
-{
-}
+FrameManager::FrameManager(std::shared_ptr<Camera> camera) : camera(camera) {}
 
 FrameManager::~FrameManager()
 {
@@ -120,18 +103,12 @@ int8_t FrameManager::create_request()
     return 0;
 }
 
-int8_t FrameManager::get_frame()
+void FrameManager::get_frames()
 {
     camera->get_camera()->requestCompleted.connect(request_complete);
     camera->get_camera()->start();
-    return 0;
-}
 
-void FrameManager::queue_requests()
-{
     for (std::unique_ptr<libcamera::Request> &request : requests) {
         camera->get_camera()->queueRequest(request.get());
     }
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 }

--- a/apps/drift-camera/src/logging.cpp
+++ b/apps/drift-camera/src/logging.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdarg>
 #include <ctime>
+#include <fstream>
 
 #include "logging.hpp"
 

--- a/apps/drift-camera/src/model.cpp
+++ b/apps/drift-camera/src/model.cpp
@@ -4,35 +4,62 @@
  *      processing
  */
 
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
 #include <sys/socket.h>
-
 #include "logging.hpp"
 #include "model.hpp"
 
 static bool box_selected = false;
 static std::vector<detection> detected_boxes;
 static detection selected_box;
+static int32_t frame_number = 0;
 
-/**
- * @brief Checks if a click is inside any bounding box
- *
- * @param event 
- * @param click_x 
- * @param click_y 
- * @param flags 
- * @param param 
- */
-static void mouse_callback(int32_t event, int32_t click_x, int32_t click_y, int32_t flags, void* param) {
-    if (event == cv::EVENT_LBUTTONDOWN) {
-        for (const auto& box : detected_boxes) {
-            if (box.box.contains(cv::Point(click_x, click_y))) {
-                selected_box = box;
-                box_selected = true;
-                return;
-            }
-        }
+const std::string jpg_basename = "frame_";
+const std::string DETECTIONS_FILE_NAME = "detections.csv";
+const std::string FORWARD_SLASH = "/";
+const std::string DEFAULT_OUTPUT_DIR = "./";
+const std::string IMAGES_DIR = "images";
+
+static inline bool check_if_directory_exists(const std::string &path)
+{
+    if (!std::filesystem::exists(path)) { 
+        return std::filesystem::create_directories(path) ? true : false;
+    } else {
+        return true;
     }
 }
+
+static std::string get_output_path(const std::string &dir_name, const std::string &file_name = "") {
+    const char* xdg_cache_home = std::getenv("XDG_CACHE_HOME");
+
+    if (xdg_cache_home && *xdg_cache_home) {
+        std::string output_dir = std::string(xdg_cache_home) + FORWARD_SLASH + dir_name;
+        if (!check_if_directory_exists(output_dir)) {
+            log_message(ERROR, "get_image_output_path(): Directory to save images to does not exist");
+        }
+
+        if (file_name != "") {
+            return output_dir + FORWARD_SLASH + file_name;
+        }
+        return output_dir + FORWARD_SLASH;
+    } else {
+        std::string output_dir = DEFAULT_OUTPUT_DIR + dir_name;
+        if (!check_if_directory_exists(output_dir)) {
+            log_message(ERROR, "get_image_output_path(): Directory to save images to does not exist");
+        }
+
+        if (file_name != "") {
+            return output_dir + FORWARD_SLASH + file_name;
+        }
+        return output_dir + FORWARD_SLASH;
+    }
+}
+
+std::ofstream detections_file(get_output_path("", DETECTIONS_FILE_NAME).c_str());
 
 constexpr float CONFIDENCE_THRESHOLD = 0.6;
 constexpr float NMS_THRESHOLD = 0.4;
@@ -48,7 +75,6 @@ constexpr uint8_t ESCAPE_KEY_CODE = 27u;
 Model::Model() : next_id(0), message_id(0)
 {
     configure_model();
-
     socket.initialize_socket();
 }
 
@@ -69,18 +95,17 @@ void Model::configure_model()
 
 void Model::process_frame(cv::Mat frame)
 {
-    //cv::setMouseCallback("Frame", mouse_callback, nullptr);
-
-    //cv::imshow("Frame", frame);
     cv::resize(frame, frame, cv::Size(MODEL_PIXEL_WIDTH, MODEL_PIXEL_HEIGHT));  // YOLOv3 typically uses 416x416 input size
+    cv::imwrite((get_output_path(IMAGES_DIR) + FORWARD_SLASH + jpg_basename + std::to_string(frame_number) + ".jpg").c_str(), frame);
     blob = cv::dnn::blobFromImage(frame, 1/255.0, cv::Size(MODEL_PIXEL_WIDTH, MODEL_PIXEL_HEIGHT), cv::Scalar(0, 0, 0), true, false);
     net.setInput(blob);
     net.forward(outputs, net.getUnconnectedOutLayersNames());
 
     detected_boxes = process_outputs(frame, outputs, class_values);
 
-    // draw_bounding_boxes(frame, detected_boxes, class_names, class_values);
-    // cv::imshow("Frame", frame);
+    draw_bounding_boxes(frame, detected_boxes, class_names, class_values);
+
+    frame_number++;
 }
 
 bool Model::end_processing() const
@@ -153,7 +178,12 @@ void Model::extract_outputs(const cv::Mat &frame, const std::vector<cv::Mat> &ou
                     int16_t delta_x = center_x - MODEL_PIXEL_CENTER_X;
                     int16_t delta_y = center_y - MODEL_PIXEL_CENTER_Y;
 
+<<<<<<< HEAD
                     log_message(INFO, "Model::extract_outputs(): Results: Confidence: %f, Area: %d, X Delta: %d, Y Delta: %d", confidence, area, delta_x, delta_y);
+=======
+                    log_message(INFO, "Model::extract_outputs(): Results: Area: %d, X Delta: %d, Y Delta: %d", area, delta_x, delta_y);
+                    detections_file << std::to_string(frame_number) << "," << left << "," << top << "," << width << "," << height << std::endl;
+>>>>>>> c2f2386 (Issue 53: Save Camera Frames and Detections (#53))
                     send_results(width * height, delta_x, delta_y);
                     return;
                 }


### PR DESCRIPTION
## Problem

We currently rely on printing log messages from our applications in order to understand what they are doing/seeing. However, it would be nice to be able to visually see what is happening in our camera app and CV model.

## Solution

1. Implement the functionality to save camera frames as a set of images.
2. Save detections in a .csv file for later processing by the GUI.

## Testing

On-drone testing.

Issue: https://github.com/ameall/drift-fw/issues/53